### PR TITLE
Bump Kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ group 'com.github.ptrteixeira'
 version '0.1.0'
 
 buildscript {
-    ext.kotlin = '1.0.5-3'
+    ext.kotlin = '1.1.0-beta-22'
     ext.wasabi = '0.3.120'
     ext.kotlintest = '1.3.5'
     ext.assertj = '3.6.1'
@@ -11,6 +11,9 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url 'https://dl.bintray.com/kotlin/kotlin-eap-1.1'
+        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin"
@@ -29,6 +32,9 @@ repositories {
     mavenCentral()
     maven {
         url 'https://dl.bintray.com/wasabifx/wasabifx'
+    }
+    maven {
+        url 'https://dl.bintray.com/kotlin/kotlin-eap-1.1'
     }
 }
 


### PR DESCRIPTION
Bump the Kotlin version from 1.0.6, a stable version, to the pre-release
version 1.1.0-beta-22. This was mostly just for fun, but I expect the
async stuff will also be nice.