### PR TITLE
Complete migration from GitLab to GitHub.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,0 @@
-image: java:8
-stages:
-  - test
-
-test:
-  stage: test
-  script:
-    - chmod +x ./gradlew
-    - ./gradlew clean check

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+Cookbook Backend
+================
+
+> Boring line-of-business application for storing recipes
+
+Simplest RESTful application in the world, just a 
+wrapper around interactions with a database.
+
+On a slightly more architectural note, this will be 
+be deployed as a service onto a PaaS provider so that 
+I can fiddle around with things. The plan is to connect 
+this to ElasticSearch as the data store.
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+machine:
+  java:
+    version: openjdk8
+
+test:
+  pre:
+    - chmod +x gradlew
+  override:
+    - ./gradlew check

--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,10 @@ machine:
   java:
     version: openjdk8
 
-test:
-  pre:
+checkout:
+  post:
     - chmod +x gradlew
+
+test:
   override:
     - ./gradlew check


### PR DESCRIPTION
Complete the migration from GitLab to GitHub. This mostly involved switching CI systems, but I also added a readme to help make this project a little neater.

To clarify, I have no ill will toward GitLab and this is not in fact related to the recent data loss at GitLab hosted. This was just because I wanted to change up some tooling.