### PR TITLE
Move from Wasabi to Vertx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ version '0.1.0'
 
 buildscript {
     ext.kotlin = '1.1.0-beta-22'
-    ext.wasabi = '0.3.120'
+    ext.vertx = '3.3.3'
     ext.kotlintest = '1.3.5'
     ext.assertj = '3.6.1'
     ext.dokka = '0.9.11'
@@ -11,9 +11,7 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
-        maven {
-            url 'https://dl.bintray.com/kotlin/kotlin-eap-1.1'
-        }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap-1.1' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin"
@@ -26,21 +24,18 @@ apply plugin: 'application'
 apply plugin: 'org.jetbrains.dokka'
 
 mainClassName = 'com.github.ptrteixeira.cookbook.MainKt'
+sourceCompatibility = '1.8'
 
 
 repositories {
     mavenCentral()
-    maven {
-        url 'https://dl.bintray.com/wasabifx/wasabifx'
-    }
-    maven {
-        url 'https://dl.bintray.com/kotlin/kotlin-eap-1.1'
-    }
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap-1.1' }
 }
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin"
-    compile "org.wasabifx:wasabi:$wasabi"
+    compile "io.vertx:vertx-core:$vertx"
+    compile "io.vertx:vertx-web:$vertx"
 
     testCompile "org.assertj:assertj-core:$assertj"
     testCompile "io.kotlintest:kotlintest:$kotlintest"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 23 15:01:44 EST 2016
+#Sat Feb 18 21:33:24 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/Main.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/Main.kt
@@ -1,16 +1,21 @@
 package com.github.ptrteixeira.cookbook
 
-import org.wasabifx.wasabi.app.AppServer
+import io.vertx.core.Vertx
+import io.vertx.ext.web.Router
+
 
 fun main(args: Array<String>) {
-    val server = AppServer()
+    val vertx = Vertx.vertx()
+    val server = vertx.createHttpServer()
+    val router = Router.router(vertx)
 
-    server.get("/", {
-        response.send("Hello, World!")
-    })
-    server.get("/first", {
-        response.send("First Page!")
-    })
+    router.route("/").handler {
+        val response = it.response()
+        response.putHeader("content-type", "text/plain")
+        response.end("Hello World!")
+    }
 
-    server.start()
+    server
+        .requestHandler(router::accept)
+        .listen(8080)
 }


### PR DESCRIPTION
This project was origninally going to be based on Wasabi, which is a
pure-ish Kotlin web framework. However, I didn't feel that Wasabi was
giving me what I wanted in terms of, eg, binding data classes to POST
bodies. So while on a high level I would have preferred to have an
as-pure-as-possible Kotlin stack, I would rather have an application
that works.