### PR TITLE
Bump Vertx version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ repositories {
 
 val versions = mapOf(
     "kotlin" to "1.1.0",
-    "vertx" to "3.3.3",
+    "vertx" to "3.4.0",
     "assertj" to "3.6.1"
 )
 


### PR DESCRIPTION
Bump Vertx version from 3.3.3 to 3.4.0. This is handy because, so far as
I can see, 3.4.0 is the first version of Vertx in which Kotlin is a
first-class citizen.