### PR TITLE
Inject configuration values via Dagger

### DIFF
--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/CookbookApplication.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/CookbookApplication.kt
@@ -1,6 +1,7 @@
 package com.github.ptrteixeira.cookbook
 
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.ptrteixeira.cookbook.base.BaseModule
 import com.github.ptrteixeira.cookbook.base.DaggerBaseComponent
 import com.github.ptrteixeira.cookbook.data.DaggerDataComponent
 import com.github.ptrteixeira.cookbook.data.DataModule
@@ -24,10 +25,12 @@ class CookbookApplication: Application<CookbookConfiguration>() {
     }
 
     override fun run(configuration: CookbookConfiguration, environment: Environment) {
-        val baseComponent = DaggerBaseComponent.create()
+        val baseComponent = DaggerBaseComponent.builder()
+            .baseModule(BaseModule(configuration, environment))
+            .build()
         val dataComponent = DaggerDataComponent.builder()
             .baseComponent(baseComponent)
-            .dataModule(DataModule(configuration, environment))
+            .dataModule(DataModule())
             .build()
         val resourcesComponent = DaggerResourcesComponent.builder()
             .dataComponent(dataComponent)

--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseComponent.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseComponent.kt
@@ -1,9 +1,13 @@
 package com.github.ptrteixeira.cookbook.base
 
+import com.codahale.metrics.MetricRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
 import dagger.Component
+import io.dropwizard.db.DataSourceFactory
 
 @Component(modules = arrayOf(BaseModule::class))
 interface BaseComponent {
     fun objectMapper(): ObjectMapper
+    fun dataSourceFactory(): DataSourceFactory
+    fun metrics(): MetricRegistry
 }

--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseModule.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseModule.kt
@@ -1,14 +1,21 @@
 package com.github.ptrteixeira.cookbook.base
 
+import com.codahale.metrics.MetricRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.ptrteixeira.cookbook.CookbookConfiguration
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
+import io.dropwizard.db.DataSourceFactory
+import io.dropwizard.setup.Environment
 
 @Module
-internal class BaseModule {
+internal class BaseModule(
+    private val config: CookbookConfiguration,
+    private val environment: Environment
+    ) {
     @Provides
     @Reusable
     fun objectMapper(): ObjectMapper {
@@ -16,4 +23,10 @@ internal class BaseModule {
         objectMapper.registerModule(Jdk8Module())
         return objectMapper
     }
+
+    @Provides
+    fun dataSourceFactory(): DataSourceFactory = config.database
+
+    @Provides
+    fun metrics(): MetricRegistry = environment.metrics()
 }

--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/base/Helpers.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/base/Helpers.kt
@@ -1,0 +1,11 @@
+package com.github.ptrteixeira.cookbook.base
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+internal fun objectMapper(): ObjectMapper {
+    val objectMapper = jacksonObjectMapper()
+    objectMapper.registerModule(Jdk8Module())
+    return objectMapper
+}

--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/base/Raw.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/base/Raw.kt
@@ -1,0 +1,16 @@
+package com.github.ptrteixeira.cookbook.base
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier annotation that indicates that an object has been created but _has not yet been
+ * configured_. It should _not_ be used outside of a function which transforms an
+ * `@Raw` instance into a real instance that can be used by other things.
+ *
+ * The particular use case of this is where I have different database connections that
+ * need to be configured the same way.
+ */
+@Qualifier
+@Retention
+@MustBeDocumented
+annotation class Raw

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/TestHelpers.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/TestHelpers.kt
@@ -1,5 +1,6 @@
-package com.github.ptrteixeira.cookbook.data
+package com.github.ptrteixeira.cookbook
 
+import com.github.ptrteixeira.cookbook.data.DataModule
 import liquibase.Contexts
 import liquibase.Liquibase
 import liquibase.database.jvm.JdbcConnection
@@ -8,9 +9,7 @@ import org.jdbi.v3.core.Jdbi
 
 internal fun jdbi(): Jdbi {
     val jdbi = Jdbi.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1")
-    jdbi.installPlugins()
-        .registerArrayType(String::class.java, "varchar")
-    return jdbi
+    return DataModule().configuredJdbi(jdbi)
 }
 
 internal fun migrate(jdbi: Jdbi)  = jdbi.inTransaction<Unit, Nothing> {

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/data/RecipeDataTest.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/data/RecipeDataTest.kt
@@ -1,5 +1,6 @@
 package com.github.ptrteixeira.cookbook.data
 
+import com.github.ptrteixeira.cookbook.jdbi
 import com.github.ptrteixeira.cookbook.model.RecipeEgg
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.sqlobject.kotlin.onDemand
@@ -97,7 +98,7 @@ class RecipeDataTest {
         @JvmStatic
         fun migrate() {
             logger.info("Running migrations before DaoTest")
-            migrate(dbi)
+            com.github.ptrteixeira.cookbook.migrate(dbi)
         }
     }
 }

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/model/PublicErrorTest.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/model/PublicErrorTest.kt
@@ -1,15 +1,13 @@
 package com.github.ptrteixeira.cookbook.model
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.ptrteixeira.cookbook.base.DaggerBaseComponent
 import io.dropwizard.testing.FixtureHelpers
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import com.github.ptrteixeira.cookbook.base.objectMapper as mapperFactory
 
 internal class PublicErrorTest {
-    private val objectMapper = DaggerBaseComponent
-        .create()
-        .objectMapper()
+    private val objectMapper = mapperFactory()
 
     private val sampleError = PublicError(ErrorType.NOT_FOUND, "Recipe 101 could not be found")
 

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/model/RecipeEggTest.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/model/RecipeEggTest.kt
@@ -1,16 +1,14 @@
 package com.github.ptrteixeira.cookbook.model
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.ptrteixeira.cookbook.base.DaggerBaseComponent
 import io.dropwizard.testing.FixtureHelpers.fixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import com.github.ptrteixeira.cookbook.base.objectMapper as mapperFactory
 
 
 internal class RecipeEggTest {
-    private val objectMapper = DaggerBaseComponent
-        .create()
-        .objectMapper()
+    private val objectMapper = mapperFactory()
 
     private val sampleRecipeEgg = RecipeEgg(
             name="Chocolate Chip Cookies",

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/model/RecipeTest.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/model/RecipeTest.kt
@@ -1,13 +1,13 @@
 package com.github.ptrteixeira.cookbook.model
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.ptrteixeira.cookbook.base.DaggerBaseComponent
 import io.dropwizard.testing.FixtureHelpers
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import com.github.ptrteixeira.cookbook.base.objectMapper as mapperFactory
 
 internal class RecipeTest {
-    private val objectMapper = DaggerBaseComponent.create().objectMapper()
+    private val objectMapper = mapperFactory()
 
     private val sampleRecipe = Recipe(
         id = 101,


### PR DESCRIPTION
Previously I was passing what amounted to the whole config yaml around
any time that I wanted to do anything. That wasn't a _great_ way to do
things, and this directly injects the configuration values rather than
the whole yaml.