### PR TITLE
Bump Kotlin version 1.1.2 -> 1.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   group = 'com.github.ptrteixeira.cookbook'
-  version = '0.1.0'
+  version = '0.2.1'
 
   repositories {
     mavenCentral()
@@ -14,8 +14,8 @@ plugins {
   id 'application'
   id 'project-report'
   id 'idea'
-  id 'org.jetbrains.kotlin.jvm' version '1.1.2-5'
-  id 'org.jetbrains.kotlin.kapt' version '1.1.2-5'
+  id 'nebula.kotlin' version '1.1.3-2'
+  id 'org.jetbrains.kotlin.kapt' version '1.1.3-2'
 }
 
 apply {

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -1,7 +1,3 @@
-buildscript {
-  ext.kotlin_version = '1.1.2-5'
-}
-
 kotlin {
   experimental {
     coroutines 'enable'
@@ -25,6 +21,6 @@ compileTestKotlin {
 }
 
 dependencies {
-  compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+  compile 'org.jetbrains.kotlin:kotlin-stdlib-jre8'
+  compile 'org.jetbrains.kotlin:kotlin-reflect'
 }


### PR DESCRIPTION
Go up a patch version. Only new feature that matters to this project
(aside from any possible bug fixes) is kapt incremental builds, which
should help drop build time.