### PR TITLE
Clean up test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M5'
+    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-RC2'
   }
 }
 

--- a/gradle/junit.gradle
+++ b/gradle/junit.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.junit_version = '5.0.0-M5'
+  ext.junit_version = '5.0.0-RC2'
 }
 
 apply {

--- a/gradle/junit.gradle
+++ b/gradle/junit.gradle
@@ -38,5 +38,9 @@ dependencies {
   testCompileOnly "org.junit.jupiter:junit-jupiter-api:$junit_version"
   testRuntime "org.junit.jupiter:junit-jupiter-engine:$junit_version"
 
+  // Vintage systems, required to work with Dropwizard resource tests :c
+  testCompile "junit:junit:4.12"
+  testRuntime "org.junit.vintage:junit-vintage-engine:4.12.0-RC2"
+
   junitXmlToHtml 'org.apache.ant:ant-junit:1.10.1'
 }

--- a/src/main/kotlin/com/github/ptrteixeira/cookbook/data/Jdbi3HealthCheck.kt
+++ b/src/main/kotlin/com/github/ptrteixeira/cookbook/data/Jdbi3HealthCheck.kt
@@ -1,7 +1,6 @@
 package com.github.ptrteixeira.cookbook.data
 
 import com.codahale.metrics.health.HealthCheck
-import com.google.common.util.concurrent.MoreExecutors
 import io.dropwizard.db.TimeBoundHealthCheck
 import io.dropwizard.util.Duration
 import org.jdbi.v3.core.Jdbi
@@ -14,9 +13,6 @@ class Jdbi3HealthCheck(
     duration: Duration
 ) : HealthCheck() {
     private val timeBound = TimeBoundHealthCheck(executorService, duration)
-
-    constructor(jdbi: Jdbi, validationQuery: String) :
-        this(jdbi, validationQuery, MoreExecutors.newDirectExecutorService(), Duration.seconds(0))
 
     public override fun check(): Result = timeBound.check {
         jdbi.withHandle<Result, Exception> {

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/TestHelpers.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/TestHelpers.kt
@@ -6,14 +6,17 @@ import liquibase.Liquibase
 import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ClassLoaderResourceAccessor
 import org.jdbi.v3.core.Jdbi
+import org.mockito.Mockito
 
 internal fun jdbi(): Jdbi {
     val jdbi = Jdbi.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1")
     return DataModule().configuredJdbi(jdbi)
 }
 
-internal fun migrate(jdbi: Jdbi)  = jdbi.inTransaction<Unit, Nothing> {
+internal fun migrate(jdbi: Jdbi) = jdbi.inTransaction<Unit, Nothing> {
     val connection = JdbcConnection(it.connection)
     val liquibase = Liquibase("migrations.xml", ClassLoaderResourceAccessor(), connection)
     liquibase.update(Contexts())
 }
+
+internal inline fun <reified T : Any> mock(): T = Mockito.mock(T::class.java)

--- a/src/test/kotlin/com/github/ptrteixeira/cookbook/resources/RecipesResourceTest.kt
+++ b/src/test/kotlin/com/github/ptrteixeira/cookbook/resources/RecipesResourceTest.kt
@@ -1,0 +1,97 @@
+package com.github.ptrteixeira.cookbook.resources
+
+import com.github.ptrteixeira.cookbook.base.objectMapper
+import com.github.ptrteixeira.cookbook.data.RecipeData
+import com.github.ptrteixeira.cookbook.mock
+import com.github.ptrteixeira.cookbook.model.Recipe
+import com.github.ptrteixeira.cookbook.model.RecipeEgg
+import io.dropwizard.testing.junit.ResourceTestRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.MediaType
+
+class RecipesResourceTest {
+    private val sampleRecipeEgg = RecipeEgg(
+        name="Chocolate Chip Cookies",
+        ingredients = listOf("Chocolate", "Chips", "Cookies"),
+        instructions = "Mix",
+        summary = "They were invented right here in Massachusetts, you know",
+        description = "They're chocolate chip cookies. Waddya want?"
+    )
+    private val sampleRecipe = sampleRecipeEgg
+        .toRecipe(1)
+
+    @Before
+    fun setUp() {
+        Mockito.reset(dao)
+    }
+
+    @Test
+    fun whenDatabaseIsEmptyResultIsEmpty() {
+        resource.target("/recipes")
+            .request()
+            .get()
+
+        verify(dao)
+            .getRecipes()
+    }
+
+    @Test
+    fun whenGetWithIdItPassesIdToDao() {
+        resource.target("/recipes/12345")
+            .request()
+            .get()
+
+        verify(dao)
+            .getRecipe(12345)
+    }
+
+    @Test
+    fun whenDeleteItPassesIdToDao() {
+        resource.target("/recipes/12345")
+            .request()
+            .delete()
+
+        verify(dao)
+            .deleteRecipe(12345)
+    }
+
+    @Test
+    fun whenCreateItReturnsRecipeWithId() {
+        given(dao.createRecipe(sampleRecipeEgg))
+            .willReturn(sampleRecipe)
+
+        val response = resource.target("/recipes")
+            .request()
+            .post(Entity.entity(sampleRecipeEgg, MediaType.APPLICATION_JSON), Recipe::class.java)
+
+        assertThat(response)
+            .isEqualTo(sampleRecipe)
+    }
+
+    @Test
+    fun whenUpdateItModifiesTheCorrectRecipe() {
+        resource.target("/recipes/12345")
+            .request()
+            .put(Entity.entity(sampleRecipeEgg, MediaType.APPLICATION_JSON), Recipe::class.java)
+
+        verify(dao).patchRecipe(12345, sampleRecipeEgg)
+    }
+
+    companion object {
+        val dao: RecipeData = mock()
+
+        @JvmStatic
+        @get:ClassRule
+        val resource: ResourceTestRule = ResourceTestRule.builder()
+            .addResource(RecipesResource(dao))
+            .setMapper(objectMapper())
+            .build()
+    }
+}


### PR DESCRIPTION
Clean up the test code. In particular:
- Write tests for the resource class. This involved adding JUnit 
  Vintage to the classpath, because Dropwizard doesn't really 
  support JUnit 5 at this time.
- Re-write the health-check code. Previously the mock wasn't running the
  callback; now it runs the callback on another mock.
- Bumps the JUnit version from M5 to RC2, which (again) was necessary 
  to get IDEA to run the tests properly.